### PR TITLE
feat: ヒント機能の実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,12 @@
 		<svg class="board" data="" w="10" h="10" type="binairo"></svg>
 	</div>
 
+	<div id="hint-popup" class="popup-overlay">
+		<div class="popup-content">
+			<span id="hint-text"></span>
+			<button id="close-popup">OK</button>
+		</div>
+	</div>
 
 	<div class="btns">
 		<div class="btn">

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -437,6 +437,47 @@ header h1 {
   fill-opacity: 0.9;
 }
 
+.popup-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+  display: none;
+}
+
+.popup-overlay.show {
+  display: flex;
+}
+
+.popup-content {
+  background: var(--bg);
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+  color: var(--main);
+  max-width: 80%;
+}
+
+#hint-text {
+  display: block;
+  margin-bottom: 20px;
+  font-size: 18px;
+}
+
+#close-popup {
+  padding: 10px 20px;
+  border: none;
+  background-color: var(--stateColored);
+  color: white;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
 .edge {
   pointer-events: none;
   -webkit-user-select: none;

--- a/src/Board/BoardNormal.ts
+++ b/src/Board/BoardNormal.ts
@@ -1,6 +1,7 @@
 import { Point } from "../Lib/Point";
 import { Util } from "../Lib/Util";
 import { Board } from "./Board";
+import { Cell } from "./Cell/Cell";
 import { CellMap } from "./Cell/CellMap";
 import { CellObject } from "./Cell/CellObject";
 import { CellState } from "./Cell/CellState";
@@ -8,6 +9,127 @@ import { EdgeMap } from "./Edge/EdgeMap";
 import { EdgeObject } from "./Edge/EdgeObject";
 
 export class BoardNormal extends Board {
+
+	getHint() {
+		for (let cell of this.cellMap) {
+			if (cell.state !== CellState.Empty) {
+				continue;
+			}
+
+			let possibleStates = [];
+			let reasons = {};
+
+			for (let state of CellState.ColoredAndWhite) {
+				let reason = this.checkViolation(cell, state);
+				if (!reason) {
+					possibleStates.push(state);
+				} else {
+					reasons[state] = reason;
+				}
+			}
+
+			if (possibleStates.length === 1) {
+				const state = possibleStates[0];
+				const oppositeState = CellState.getOpposite(state);
+				const reason = reasons[oppositeState];
+				return { cell, state, reason };
+			}
+		}
+		return null;
+	}
+
+	checkViolation(cell: Cell, state: number): string | null {
+		let reason = this.isTriumvirate(cell, state);
+		if (reason) return reason;
+
+		reason = this.isBalanceViolated(cell, state);
+		if (reason) return reason;
+
+		reason = this.isUniquenessViolated(cell, state);
+		if (reason) return reason;
+
+		return null;
+	}
+
+	isTriumvirate(cell: Cell, state: number): string | null {
+		const { x, y } = cell;
+		const w = this.cellMap.w;
+		const h = this.cellMap.h;
+
+		// Horizontal check
+		if (x > 1 && this.cellMap.get(x - 1, y).state === state && this.cellMap.get(x - 2, y).state === state) return "三連禁止";
+		if (x < w - 2 && this.cellMap.get(x + 1, y).state === state && this.cellMap.get(x + 2, y).state === state) return "三連禁止";
+		if (x > 0 && x < w - 1 && this.cellMap.get(x - 1, y).state === state && this.cellMap.get(x + 1, y).state === state) return "三連禁止";
+
+		// Vertical check
+		if (y > 1 && this.cellMap.get(x, y - 1).state === state && this.cellMap.get(x, y - 2).state === state) return "三連禁止";
+		if (y < h - 2 && this.cellMap.get(x, y + 1).state === state && this.cellMap.get(x, y + 2).state === state) return "三連禁止";
+		if (y > 0 && y < h - 1 && this.cellMap.get(x, y - 1).state === state && this.cellMap.get(x, y + 1).state === state) return "三連禁止";
+
+		return null;
+	}
+
+	isBalanceViolated(cell: Cell, state: number): string | null {
+		const row = this.cellMap.rows[cell.y];
+		const column = this.cellMap.columns[cell.x];
+		const maxCount = this.cellMap.w / 2;
+
+		let rowCount = 0;
+		for (let c of row) {
+			if (c.state === state) rowCount++;
+		}
+		if (rowCount >= maxCount) return `バランス (行)`;
+
+		let colCount = 0;
+		for (let c of column) {
+			if (c.state === state) colCount++;
+		}
+		if (colCount >= maxCount) return `バランス (列)`;
+
+		return null;
+	}
+
+	isUniquenessViolated(cell: Cell, state: number): string | null {
+		// Temporarily set the state
+		cell.state = state;
+
+		const checkUniqueness = (line: CellMap, allLines: CellMap[]): boolean => {
+			if (line.some(c => c.state === CellState.Empty)) {
+				return false; // Not a complete line
+			}
+
+			const lineSignature = line.map(c => c.state).join('');
+
+			for (let otherLine of allLines) {
+				if (line === otherLine) continue;
+				if (otherLine.some(c => c.state === CellState.Empty)) continue;
+
+				const otherLineSignature = otherLine.map(c => c.state).join('');
+				if (lineSignature === otherLineSignature) {
+					return true; // Found a duplicate
+				}
+			}
+			return false;
+		}
+
+		let isViolated = false;
+		const row = this.cellMap.rows[cell.y];
+		if (checkUniqueness(row, this.cellMap.rows)) {
+			isViolated = true;
+		}
+
+		if (!isViolated) {
+			const column = this.cellMap.columns[cell.x];
+			if (checkUniqueness(column, this.cellMap.columns)) {
+				isViolated = true;
+			}
+		}
+
+		// Revert the state
+		cell.state = CellState.Empty;
+
+		return isViolated ? `ユニーク` : null;
+	}
 
 	initCellMap() {
 		let data: number[] = Util.toNumber64(this.elem.getAttribute("data"))

--- a/src/Board/Cell/CellObject.ts
+++ b/src/Board/Cell/CellObject.ts
@@ -112,8 +112,7 @@ export class CellObject extends SvgObject {
 	}
 
 	setHint() {
-		// this.addChild(new SvgRect(this.cell.x + 0.2, this.cell.y + 0.2, 0.6, 0.6))
-		// this.addChild(new SvgCircle(this.cell.x + 0.5, this.cell.y + 0.5, 0.3))
+		this.setAttribute("hint", "");
 	}
 
 	updateState(state: number) {

--- a/src/UI/Btn/HintBtn.ts
+++ b/src/UI/Btn/HintBtn.ts
@@ -1,11 +1,23 @@
 import { Board } from "../../Board/Board";
+import { BoardNormal } from "../../Board/BoardNormal";
+import { Popup } from "../Popup";
 import { Btn } from "./Btn";
 
 export class HintBtn extends Btn {
 
 	onClick() {
-		Board.main.getHint()
-		// Board.main.getHint()
+		const board = Board.main as BoardNormal;
+		if (!board.getHint) return;
+
+		const hint = board.getHint();
+
+		if (hint) {
+			hint.cell.object.setHint();
+			const reasonText = `このセルは「${hint.reason}」のルールにより ${hint.state === 0 ? "色付き(0)" : "白(1)"} になります。`;
+			Popup.I.show(reasonText);
+		} else {
+			Popup.I.show("確定できるセルは見つかりませんでした。");
+		}
 	}
 
 }

--- a/src/UI/Popup.ts
+++ b/src/UI/Popup.ts
@@ -1,0 +1,30 @@
+export class Popup {
+    static I: Popup;
+
+    private overlay: HTMLElement;
+    private textElement: HTMLElement;
+    private closeButton: HTMLElement;
+
+    constructor() {
+        Popup.I = this;
+        this.overlay = document.getElementById('hint-popup');
+        this.textElement = document.getElementById('hint-text');
+        this.closeButton = document.getElementById('close-popup');
+
+        this.closeButton.addEventListener('click', () => this.hide());
+        this.overlay.addEventListener('click', (e) => {
+            if (e.target === this.overlay) {
+                this.hide();
+            }
+        });
+    }
+
+    show(message: string) {
+        this.textElement.innerText = message;
+        this.overlay.classList.add('show');
+    }
+
+    hide() {
+        this.overlay.classList.remove('show');
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { InputMng } from "./Lib/InputMng";
 import { Point } from "./Lib/Point";
 import { OperationMng } from "./Operation/OperationMng";
 import { SymbolMng } from "./Symbol/SymbolMng";
+import { Popup } from "./UI/Popup";
 import { UI } from "./UI/UI";
 
 document.addEventListener('DOMContentLoaded', e => {
@@ -14,6 +15,7 @@ document.addEventListener('DOMContentLoaded', e => {
 	new InputMng()
 	new OperationMng()
 	new SymbolMng()
+	new Popup()
 
 	const sizeSelector = document.getElementById('size-selector') as HTMLSelectElement;
 	if (sizeSelector) {


### PR DESCRIPTION
バイナリパズルにヒント機能を追加しました。

この機能は以下の要素から構成されています。
- 確定可能なセルを特定するロジック (`BoardNormal.ts`)
- どのルール（三連禁止、バランス、ユニークネス）に基づいてセルが確定されたかを説明するポップアップ
- 確定可能なセルを視覚的にハイライトする機能

これらの機能は、`HintBtn`のクリックイベントによってトリガーされます。