### PR TITLE
feat: ヒント機能の実装 (修正)

### DIFF
--- a/src/Board/BoardBinairo.ts
+++ b/src/Board/BoardBinairo.ts
@@ -2,6 +2,7 @@ import { PuzzleGenerator } from "../logic/PuzzleGenerator";
 import { Point } from "../Lib/Point";
 import { Util } from "../Lib/Util";
 import { Board } from "./Board";
+import { Cell } from "./Cell/Cell";
 import { CellMap } from "./Cell/CellMap";
 import { CellObject } from "./Cell/CellObject";
 import { CellState } from "./Cell/CellState";
@@ -104,7 +105,123 @@ export class BoardBinairo extends Board {
 	}
 
 	getHint() {
+		for (let cell of this.cellMap) {
+			if (cell.state !== CellState.Empty) {
+				continue;
+			}
+
+			let possibleStates = [];
+			let reasons = {};
+
+			for (let state of CellState.ColoredAndWhite) {
+				let reason = this.checkViolation(cell, state);
+				if (!reason) {
+					possibleStates.push(state);
+				} else {
+					reasons[state] = reason;
+				}
+			}
+
+			if (possibleStates.length === 1) {
+				const state = possibleStates[0];
+				const oppositeState = CellState.getOpposite(state);
+				const reason = reasons[oppositeState];
+				return { cell, state, reason };
+			}
+		}
+		return null;
 	}
 
+	checkViolation(cell: Cell, state: number): string | null {
+		let reason = this.isTriumvirate(cell, state);
+		if (reason) return reason;
 
+		reason = this.isBalanceViolated(cell, state);
+		if (reason) return reason;
+
+		reason = this.isUniquenessViolated(cell, state);
+		if (reason) return reason;
+
+		return null;
+	}
+
+	isTriumvirate(cell: Cell, state: number): string | null {
+		const { x, y } = cell;
+		const w = this.cellMap.w;
+		const h = this.cellMap.h;
+
+		// Horizontal check
+		if (x > 1 && this.cellMap.get(x - 1, y).state === state && this.cellMap.get(x - 2, y).state === state) return "三連禁止";
+		if (x < w - 2 && this.cellMap.get(x + 1, y).state === state && this.cellMap.get(x + 2, y).state === state) return "三連禁止";
+		if (x > 0 && x < w - 1 && this.cellMap.get(x - 1, y).state === state && this.cellMap.get(x + 1, y).state === state) return "三連禁止";
+
+		// Vertical check
+		if (y > 1 && this.cellMap.get(x, y - 1).state === state && this.cellMap.get(x, y - 2).state === state) return "三連禁止";
+		if (y < h - 2 && this.cellMap.get(x, y + 1).state === state && this.cellMap.get(x, y + 2).state === state) return "三連禁止";
+		if (y > 0 && y < h - 1 && this.cellMap.get(x, y - 1).state === state && this.cellMap.get(x, y + 1).state === state) return "三連禁止";
+
+		return null;
+	}
+
+	isBalanceViolated(cell: Cell, state: number): string | null {
+		const row = this.cellMap.rows[cell.y];
+		const column = this.cellMap.columns[cell.x];
+		const maxCount = this.cellMap.w / 2;
+
+		let rowCount = 0;
+		for (let c of row) {
+			if (c.state === state) rowCount++;
+		}
+		if (rowCount >= maxCount) return `バランス (行)`;
+
+		let colCount = 0;
+		for (let c of column) {
+			if (c.state === state) colCount++;
+		}
+		if (colCount >= maxCount) return `バランス (列)`;
+
+		return null;
+	}
+
+	isUniquenessViolated(cell: Cell, state: number): string | null {
+		// Temporarily set the state
+		cell.state = state;
+
+		const checkUniqueness = (line: CellMap, allLines: CellMap[]): boolean => {
+			if (line.some(c => c.state === CellState.Empty)) {
+				return false; // Not a complete line
+			}
+
+			const lineSignature = line.map(c => c.state).join('');
+
+			for (let otherLine of allLines) {
+				if (line === otherLine) continue;
+				if (otherLine.some(c => c.state === CellState.Empty)) continue;
+
+				const otherLineSignature = otherLine.map(c => c.state).join('');
+				if (lineSignature === otherLineSignature) {
+					return true; // Found a duplicate
+				}
+			}
+			return false;
+		}
+
+		let isViolated = false;
+		const row = this.cellMap.rows[cell.y];
+		if (checkUniqueness(row, this.cellMap.rows)) {
+			isViolated = true;
+		}
+
+		if (!isViolated) {
+			const column = this.cellMap.columns[cell.x];
+			if (checkUniqueness(column, this.cellMap.columns)) {
+				isViolated = true;
+			}
+		}
+
+		// Revert the state
+		cell.state = CellState.Empty;
+
+		return isViolated ? `ユニーク` : null;
+	}
 }

--- a/src/Board/BoardNormal.ts
+++ b/src/Board/BoardNormal.ts
@@ -1,7 +1,6 @@
 import { Point } from "../Lib/Point";
 import { Util } from "../Lib/Util";
 import { Board } from "./Board";
-import { Cell } from "./Cell/Cell";
 import { CellMap } from "./Cell/CellMap";
 import { CellObject } from "./Cell/CellObject";
 import { CellState } from "./Cell/CellState";
@@ -9,127 +8,6 @@ import { EdgeMap } from "./Edge/EdgeMap";
 import { EdgeObject } from "./Edge/EdgeObject";
 
 export class BoardNormal extends Board {
-
-	getHint() {
-		for (let cell of this.cellMap) {
-			if (cell.state !== CellState.Empty) {
-				continue;
-			}
-
-			let possibleStates = [];
-			let reasons = {};
-
-			for (let state of CellState.ColoredAndWhite) {
-				let reason = this.checkViolation(cell, state);
-				if (!reason) {
-					possibleStates.push(state);
-				} else {
-					reasons[state] = reason;
-				}
-			}
-
-			if (possibleStates.length === 1) {
-				const state = possibleStates[0];
-				const oppositeState = CellState.getOpposite(state);
-				const reason = reasons[oppositeState];
-				return { cell, state, reason };
-			}
-		}
-		return null;
-	}
-
-	checkViolation(cell: Cell, state: number): string | null {
-		let reason = this.isTriumvirate(cell, state);
-		if (reason) return reason;
-
-		reason = this.isBalanceViolated(cell, state);
-		if (reason) return reason;
-
-		reason = this.isUniquenessViolated(cell, state);
-		if (reason) return reason;
-
-		return null;
-	}
-
-	isTriumvirate(cell: Cell, state: number): string | null {
-		const { x, y } = cell;
-		const w = this.cellMap.w;
-		const h = this.cellMap.h;
-
-		// Horizontal check
-		if (x > 1 && this.cellMap.get(x - 1, y).state === state && this.cellMap.get(x - 2, y).state === state) return "三連禁止";
-		if (x < w - 2 && this.cellMap.get(x + 1, y).state === state && this.cellMap.get(x + 2, y).state === state) return "三連禁止";
-		if (x > 0 && x < w - 1 && this.cellMap.get(x - 1, y).state === state && this.cellMap.get(x + 1, y).state === state) return "三連禁止";
-
-		// Vertical check
-		if (y > 1 && this.cellMap.get(x, y - 1).state === state && this.cellMap.get(x, y - 2).state === state) return "三連禁止";
-		if (y < h - 2 && this.cellMap.get(x, y + 1).state === state && this.cellMap.get(x, y + 2).state === state) return "三連禁止";
-		if (y > 0 && y < h - 1 && this.cellMap.get(x, y - 1).state === state && this.cellMap.get(x, y + 1).state === state) return "三連禁止";
-
-		return null;
-	}
-
-	isBalanceViolated(cell: Cell, state: number): string | null {
-		const row = this.cellMap.rows[cell.y];
-		const column = this.cellMap.columns[cell.x];
-		const maxCount = this.cellMap.w / 2;
-
-		let rowCount = 0;
-		for (let c of row) {
-			if (c.state === state) rowCount++;
-		}
-		if (rowCount >= maxCount) return `バランス (行)`;
-
-		let colCount = 0;
-		for (let c of column) {
-			if (c.state === state) colCount++;
-		}
-		if (colCount >= maxCount) return `バランス (列)`;
-
-		return null;
-	}
-
-	isUniquenessViolated(cell: Cell, state: number): string | null {
-		// Temporarily set the state
-		cell.state = state;
-
-		const checkUniqueness = (line: CellMap, allLines: CellMap[]): boolean => {
-			if (line.some(c => c.state === CellState.Empty)) {
-				return false; // Not a complete line
-			}
-
-			const lineSignature = line.map(c => c.state).join('');
-
-			for (let otherLine of allLines) {
-				if (line === otherLine) continue;
-				if (otherLine.some(c => c.state === CellState.Empty)) continue;
-
-				const otherLineSignature = otherLine.map(c => c.state).join('');
-				if (lineSignature === otherLineSignature) {
-					return true; // Found a duplicate
-				}
-			}
-			return false;
-		}
-
-		let isViolated = false;
-		const row = this.cellMap.rows[cell.y];
-		if (checkUniqueness(row, this.cellMap.rows)) {
-			isViolated = true;
-		}
-
-		if (!isViolated) {
-			const column = this.cellMap.columns[cell.x];
-			if (checkUniqueness(column, this.cellMap.columns)) {
-				isViolated = true;
-			}
-		}
-
-		// Revert the state
-		cell.state = CellState.Empty;
-
-		return isViolated ? `ユニーク` : null;
-	}
 
 	initCellMap() {
 		let data: number[] = Util.toNumber64(this.elem.getAttribute("data"))

--- a/src/UI/Btn/HintBtn.ts
+++ b/src/UI/Btn/HintBtn.ts
@@ -1,12 +1,12 @@
 import { Board } from "../../Board/Board";
-import { BoardNormal } from "../../Board/BoardNormal";
+import { BoardBinairo } from "../../Board/BoardBinairo";
 import { Popup } from "../Popup";
 import { Btn } from "./Btn";
 
 export class HintBtn extends Btn {
 
 	onClick() {
-		const board = Board.main as BoardNormal;
+		const board = Board.main as BoardBinairo;
 		if (!board.getHint) return;
 
 		const hint = board.getHint();


### PR DESCRIPTION
バイナリパズルにヒント機能を追加しました。
ロジックを`BoardNormal.ts`から`BoardBinairo.ts`に移動し、
正しいボードタイプで機能するように修正しました。

この機能は以下の要素から構成されています。
- 確定可能なセルを特定するロジック (`BoardBinairo.ts`)
- どのルール（三連禁止、バランス、ユニークネス）に基づいてセルが確定されたかを説明するポップアップ
- 確定可能なセルを視覚的にハイライトする機能

これらの機能は、`HintBtn`のクリックイベントによってトリガーされます。